### PR TITLE
Span context

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 120
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- No unreleased changes currently.
+
+## [0.2.0]
+
+### Changed
+- Update to use `continue_trace/3` with a `Spandex.SpanContext` struct instead
+  of `continue_trace/4` with a `trace_id` and `span_id`.
+
+[0.2.0]: https://github.com/spandex-project/spandex_ecto/compare/v0.2.0...v0.1.0
+
+### Changed
+
+## [0.1.0]
+
+### Added
+- Initial release of the `spandex_ecto` library.
+
+[0.1.0]: https://github.com/spandex-project/spandex_ecto/commit/c0ab823e2ab5af5ed9953f5ec5008bf34ffa4f4e

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule SpandexEcto.MixProject do
     [
       app: :spandex_ecto,
       description: description(),
-      version: "0.1.0",
-      elixir: "~> 1.7",
+      version: "0.2.0",
+      elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package()
@@ -23,7 +23,7 @@ defmodule SpandexEcto.MixProject do
   defp package do
     [
       name: :spandex_ecto,
-      maintainers: ["Zachary Daniel"],
+      maintainers: ["Zachary Daniel", "Greg Mefford"],
       licenses: ["MIT License"],
       links: %{"GitHub" => "https://github.com/spandex-project/spandex_ecto"}
     ]
@@ -38,7 +38,8 @@ defmodule SpandexEcto.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:spandex, "~> 2.2"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,5 +3,9 @@
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
+  "optimal": {:hex, :optimal, "0.3.6", "46bbf52fbbbd238cda81e02560caa84f93a53c75620f1fe19e81e4ae7b07d1dd", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.6.2", "e06a7bd2bb6de5145da0dd950070110dce88045351224bd98e84edfdaaf5ffee", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "spandex": {:hex, :spandex, "2.2.0", "0d60e2a232074ebf6e299edcd3ee540df87541246ba5f5bd84c68a9bb00171bc", [:mix], [{:optimal, "~> 0.3.3", [hex: :optimal, repo: "hexpm", optional: false]}, {:plug, ">= 1.0.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/spandex_ecto_test.exs
+++ b/test/spandex_ecto_test.exs
@@ -1,8 +1,0 @@
-defmodule SpandexEctoTest do
-  use ExUnit.Case
-  doctest SpandexEcto
-
-  test "greets the world" do
-    assert SpandexEcto.hello() == :world
-  end
-end


### PR DESCRIPTION
Pass a `SpanContext` struct to `continue_trace` since the `trace_id` + `span_id` method is deprecated. I still need to manually validate that this code works, since there are currently no tests. 😬 

I'll work on some tests at some point, but for now I just want to make these small tweaks and assume it used to work. 😅 