### PR TITLE
Use a more direct Process.info call to avoid performance penalties

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -103,7 +103,7 @@ defmodule SpandexEcto.EctoLogger do
     if caller_pid == self() do
       tracer.start_span("query")
     else
-      case Process.info(caller_pid)[:dictionary][:spandex_trace] do
+      case Process.info(caller_pid, :dictionary)[:spandex_trace] do
         nil ->
           tracer.start_trace("query")
 


### PR DESCRIPTION
Per the Elixir and Erlang docs, `Process.info/1` should only be used for debugging purposes, as it can have significant performance issues when used on busy processes. Fortunately we can easily replace it with `Process.info/2` in this case.