### PR TITLE
feat: truncate queries, 5000 character default

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -14,7 +14,7 @@ defmodule SpandexEcto.EctoLogger do
     config = Application.get_env(:spandex_ecto, __MODULE__)
     tracer = config[:tracer] || raise "tracer is a required option for #{inspect(__MODULE__)}"
     service = config[:service] || :ecto
-    truncate = config[:truncate] || 4000
+    truncate = config[:truncate] || 5000
 
     if tracer.current_trace_id() do
       now = :os.system_time(:nano_seconds)

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -14,10 +14,15 @@ defmodule SpandexEcto.EctoLogger do
     config = Application.get_env(:spandex_ecto, __MODULE__)
     tracer = config[:tracer] || raise "tracer is a required option for #{inspect(__MODULE__)}"
     service = config[:service] || :ecto
+    truncate = config[:truncate] || 4000
 
     if tracer.current_trace_id() do
       now = :os.system_time(:nano_seconds)
-      query = string_query(log_entry)
+      query =
+        log_entry
+        |> string_query()
+        |> String.slice(0, truncate)
+
       num_rows = num_rows(log_entry)
 
       queue_time = get_time(log_entry, :queue_time)


### PR DESCRIPTION
The reason for the default of 5000 is that the agent truncates the query to 5000 characters anyway, except that some rudimentary tests show that it causes memory/performance issues in the agent. I didn't bother getting too extensive, because there is no reason not to truncate on our end first.