### PR TITLE
Change 'nanoseconds' to 'nanosecond'

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -105,7 +105,7 @@ defmodule SpandexEcto.EctoLogger do
     |> to_nanoseconds()
   end
 
-  defp to_nanoseconds(time) when is_integer(time), do: System.convert_time_unit(time, :native, :nanoseconds)
+  defp to_nanoseconds(time) when is_integer(time), do: System.convert_time_unit(time, :native, :nanosecond)
   defp to_nanoseconds(_time), do: 0
 
   defp tags(%{params: params}) when is_list(params) do


### PR DESCRIPTION
Since https://github.com/elixir-lang/elixir/issues/5236, Elixir has standardised time units as singular, therefore the existing

```elixir
System.convert_time_unit(time, :native, :nanoseconds)
```

call results in a deprecation warning.