### PR TITLE
add support for Ecto 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ config :my_app, MyApp.Repo,
 
 ```elixir
 # in application.ex
-:telemetry.attach("spandex-query-tracer", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4)
+:telemetry.attach("spandex-query-tracer", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
 ```
 
 If your repo is not named like `MyApp.Repo`, you'll need to set `:telemetry_prefix` in your repo config:

--- a/README.md
+++ b/README.md
@@ -28,16 +28,34 @@ def deps do
 end
 ```
 
-Configuration
+## Configuration
 
 ```elixir
 config :spandex_ecto, SpandexEcto.EctoLogger,
   service: :ecto, # Optional
   tracer: MyApp.Tracer, # Required
+```
 
+### For Ecto 2
+
+```elixir
 # Be aware that this is a *compile* time configuration. As such, if you change this you
 # may need to `mix compile --force` and/or `mix deps.compile --force ecto`
 config :my_app, MyApp.Repo,
   loggers: [{Ecto.LogEntry, :log, [:info]}, {SpandexEcto.EctoLogger, :trace, ["database_name"]}]
 
+```
+
+### For Ecto 3
+
+```elixir
+# in application.ex
+:telemetry.attach("spandex-query-tracer", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4)
+```
+
+If your repo is not named like `MyApp.Repo`, you'll need to set `:telemetry_prefix` in your repo config:
+
+```elixir
+config :my_app, MyApp.Something.RepoName,
+  telemetry_prefix: [:my_app, :repo_name]
 ```

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -1,0 +1,23 @@
+defmodule SpandexEcto.TelemetryAdapter do
+  alias SpandexEcto.EctoLogger
+
+  #  this is for ecto_sql 3.0.x
+  def handle_event([_app_name, repo_name, :query], total_time, log_entry, _config) when is_integer(total_time) do
+    EctoLogger.trace(log_entry, "#{repo_name}_database")
+  end
+
+  # This is for ecto_sql >= 3.1
+  def handle_event([_app_name, repo_name, :query], measurements, metadata, _config) when is_map(measurements) do
+    log_entry = %{
+      query: metadata.query,
+      source: metadata.source,
+      params: metadata.params,
+      query_time: Map.get(measurements, :query_time, 0),
+      decode_time: Map.get(measurements, :decode_time, 0),
+      queue_time: Map.get(measurements, :queue_time, 0),
+      result: {metadata.result, "n/a"}
+    }
+
+    EctoLogger.trace(log_entry, "#{repo_name}_database")
+  end
+end

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -19,9 +19,12 @@ defmodule SpandexEcto.TelemetryAdapter do
       query_time: Map.get(measurements, :query_time, 0),
       decode_time: Map.get(measurements, :decode_time, 0),
       queue_time: Map.get(measurements, :queue_time, 0),
-      result: {metadata.result, "n/a"}
+      result: wrap_result(metadata.result)
     }
 
     EctoLogger.trace(log_entry, "#{repo_name}_database")
   end
+
+  defp wrap_result(result) when is_atom(result), do: {result, "n/a"}
+  defp wrap_result(result), do: result
 end

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -25,6 +25,12 @@ defmodule SpandexEcto.TelemetryAdapter do
     EctoLogger.trace(log_entry, "#{repo_name}_database")
   end
 
+  def handle_event(event_name, measurements, log_entry, config) when is_list(event_name) do
+    event_name
+    |> tl()
+    |> handle_event(measurements, log_entry, config)
+  end
+
   defp wrap_result(result) when is_atom(result), do: {result, "n/a"}
   defp wrap_result(result), do: result
 end

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -1,4 +1,8 @@
 defmodule SpandexEcto.TelemetryAdapter do
+  @moduledoc """
+  This module provides event handler functions for telemetry
+  """
+
   alias SpandexEcto.EctoLogger
 
   #  this is for ecto_sql 3.0.x


### PR DESCRIPTION
This is an attempt to support Ecto 3, so that deprecation warning for loggers section is fixed (Issue #8).
Thanks @novaugust for [the idea](https://github.com/spandex-project/spandex_ecto/issues/8#issuecomment-478376776)