### PR TITLE
Update Ebert readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Inline docs](http://inch-ci.org/github/spandex-project/spandex_ecto.svg)](http://inch-ci.org/github/spandex-project/spandex_ecto)
 [![Coverage Status](https://coveralls.io/repos/github/spandex-project/spandex_ecto/badge.svg)](https://coveralls.io/github/spandex-project/spandex_ecto)
 [![Hex pm](http://img.shields.io/hexpm/v/spandex_ecto.svg?style=flat)](https://hex.pm/packages/spandex_ecto)
-[![Ebert](https://ebertapp.io/github/spandex-project/spandex_ecto.svg)](https://ebertapp.io/github/spandex-project/spandex_ecto)
+[![SourceLevel](https://sourcelevel.io/github/spandex-project/spandex_ecto.svg)](https://sourcelevel.io/github/spandex-project/spandex_ecto)
 
 Tools for integrating Ecto with Spandex
 


### PR DESCRIPTION
Ebert has been [renamed to SourceLevel](https://sourcelevel.io/blog/ebert-is-now-sourcelevel), and the badge is broken.

This pr updates the readme to point it to the new domain.