### PR TITLE
docs: Ecto 3 example update to better guide setups with multiple repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ config :my_app, MyApp.Repo,
 
 ```elixir
 # in application.ex
-:telemetry.attach("spandex-query-tracer", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
+:telemetry.attach("spandex-query-tracer-repo_name", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
 ```
 
 > NOTE: **If you are upgrading from Ecto 2**, make sure to **remove** the `loggers`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ config :my_app, MyApp.Repo,
 
 ```elixir
 # in application.ex
-:telemetry.attach("spandex-query-tracer-repo_name", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
+:ok = :telemetry.attach("spandex-query-tracer-repo_name", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
 ```
 
 > NOTE: **If you are upgrading from Ecto 2**, make sure to **remove** the `loggers`


### PR DESCRIPTION
The first argument to `:telemry.attach/4` needs to be unique otherwise it will return an error tuple saying it is already attached.  I ran into this issue in an application that has multiple Ecto Repos and I didn't update the first argument to be unique. Which took me a while to track down why I was getting data for one of my repos but not the other. 

I figure if the example includes something that should be unique per repo name that may help others with multiple repos. 

Alternatively we could include a match so it would fail the match on assignment `:ok = :telemry.attach(...`  I figured the intention isn't as clear though. 