### PR TITLE
fix: remove outdated requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,3 @@ config :my_app, MyApp.Repo,
 
 > NOTE: **If you are upgrading from Ecto 2**, make sure to **remove** the `loggers`
 > entry from your configuration after adding the `:telemetry.attach`.
-
-If your repo is not named like `MyApp.Repo`, you'll need to set `:telemetry_prefix` in your repo config:
-
-```elixir
-config :my_app, MyApp.Something.RepoName,
-  telemetry_prefix: [:my_app, :repo_name]
-```


### PR DESCRIPTION
Hi gang. It's me again.
I was sad that that requirement existed, then when i was look at source code realized it was out of date! 3a37de1bfa23825456a64676c260273b83ec9b77 fixed the telemety prefix requirement. This just updates the readme to remove the erroneously stated requirement