### PR TITLE
Update Telemetry matcher in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ config :my_app, MyApp.Repo,
 
 ```elixir
 # in application.ex
-:ok = :telemetry.attach("spandex-query-tracer-repo_name", [:my_app, :repo_name, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
+:ok = :telemetry.attach("spandex-query-tracer-repo_name", [:my_app, :repo, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
 ```
 
 > NOTE: **If you are upgrading from Ecto 2**, make sure to **remove** the `loggers`

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ config :my_app, MyApp.Repo,
 
 ```elixir
 # in application.ex
+# If your repo is called `MyApp.Repo`, use `[:my_app, :repo, :query]`
+# If your repo is called `Foo.Bar.Baz`, use `[:foo, :bar, :baz, :query]`
 :ok = :telemetry.attach("spandex-query-tracer-repo_name", [:my_app, :repo, :query], &SpandexEcto.TelemetryAdapter.handle_event/4, nil)
 ```
 


### PR DESCRIPTION
The [Ecto Telemetry docs](https://hexdocs.pm/ecto/Ecto.Repo.html#module-ecto-telemetry-events) show the event to attach to is `[:my_app, :repo, :query]`.