### PR TITLE
Add possibility to pass the span's resource through :telemetry_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,17 @@ You can override the global configuration by passing overrides to `:telemetry.at
 
 The following configuration options are supported:
 
-|Option|Description|Default|
-|-|-|-|
-|`tracer`|Tracer instance to use for reporting traces (*required*)||
-|`service`|Service name for Ecto traces|`ecto`|
-|`truncate`|Maximum length of a query (excess will be truncated)|5000|
+| Option     | Description                                              | Default |
+| ---------- | -------------------------------------------------------- | ------- |
+| `tracer`   | Tracer instance to use for reporting traces (_required_) |         |
+| `service`  | Service name for Ecto traces                             | `ecto`  |
+| `truncate` | Maximum length of a query (excess will be truncated)     | 5000    |
 
 ### Ecto 2
 
 To integrate `SpandexEcto` with pre-`:telemetry` versions of Ecto you need to add `SpandexEcto.EctoLogger` as a logger to your repository.
 
-Be aware that this is a *compile* time configuration. As such, if you change this you may need to `mix compile --force` and/or `mix deps.compile --force ecto`.
+Be aware that this is a _compile_ time configuration. As such, if you change this you may need to `mix compile --force` and/or `mix deps.compile --force ecto`.
 
 ```elixir
 # config/config.exs
@@ -96,4 +96,18 @@ config :my_app, MyApp.Repo,
     {Ecto.LogEntry, :log, [:info]},
     {SpandexEcto.EctoLogger, :trace, ["database_name"]}
   ]
+```
+
+## Customizing Span Resources
+
+By default, SpandexEcto uses the query as name for the span's resource. In
+order get a better feeling for the context of your spans, you can label your
+span's resources using the option [`:telemetry_options`](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
+of almost all of `Ecto.Repo`'s repository functions.
+
+### Examples
+
+```elixir
+Repo.all(query, telemetry_options: [spandex_resource: "users-with-addresses"])
+Repo.get!(User, id, telemetry_options: [spandex_resource: "get-user"])
 ```

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -31,6 +31,7 @@ defmodule SpandexEcto.EctoLogger do
         |> String.slice(0, truncate)
 
       num_rows = num_rows(log_entry)
+      resource = log_entry[:resource] || query
 
       queue_time = get_time(log_entry, :queue_time)
       query_time = get_time(log_entry, :query_time)
@@ -43,7 +44,7 @@ defmodule SpandexEcto.EctoLogger do
         start: start,
         completion_time: now,
         service: service,
-        resource: query,
+        resource: resource,
         type: :db,
         sql_query: [
           query: query,

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -19,7 +19,8 @@ defmodule SpandexEcto.TelemetryAdapter do
       query_time: Map.get(measurements, :query_time, 0),
       decode_time: Map.get(measurements, :decode_time, 0),
       queue_time: Map.get(measurements, :queue_time, 0),
-      result: wrap_result(metadata.result)
+      result: wrap_result(metadata.result),
+      resource: get_in(metadata, [:options, :spandex, :resource])
     }
 
     EctoLogger.trace(log_entry, "#{repo_name}_database", config)

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -20,7 +20,7 @@ defmodule SpandexEcto.TelemetryAdapter do
       decode_time: Map.get(measurements, :decode_time, 0),
       queue_time: Map.get(measurements, :queue_time, 0),
       result: wrap_result(metadata.result),
-      resource: get_in(metadata, [:options, :spandex, :resource])
+      resource: get_in(metadata, [:options, :spandex_resource])
     }
 
     EctoLogger.trace(log_entry, "#{repo_name}_database", config)


### PR DESCRIPTION
I always find it hard to distinct the spans created by `spandex_ecto` as the resource is set to the query. I think it would be nice to be able to set the resource when running the query, don't you think? ecto offers an option `:telemetry_options` that is passed to the handler as `opts[:options]`. My change allows to run a query as follows to define the resource. If it is not defined, the code falls back to using the query as resource.

```elixir
Repo.all(query, telemetry_options: %{spandex: %{resource: "users-with-addresses"}})
Repo.get!(User, id, telemetry_options: %{spandex: %{resource: "get-user"}})
```

What do you think of this proposal?