### PR TITLE
[B1M2-1167] Allow setting tracer at runtime

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -14,7 +14,7 @@ defmodule SpandexEcto.EctoLogger do
   def trace(log_entry, database) do
     # Put in your own configuration here
     config = Application.get_env(:spandex_ecto, __MODULE__)
-    tracer = config[:tracer] || raise "tracer is a required option for #{inspect(__MODULE__)}"
+    tracer = config[:tracer]
     service = config[:service] || :ecto
     truncate = config[:truncate] || 5000
 


### PR DESCRIPTION
Allow setting tracer at runtime for spandex_ecto. Removes raising error if tracer config is not set. 