### PR TITLE
TECH: Change span type to custom to allow APM deployment tracking

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -44,7 +44,7 @@ defmodule SpandexEcto.EctoLogger do
         completion_time: now,
         service: service,
         resource: query,
-        type: :db,
+        type: :custom,
         sql_query: [
           query: query,
           rows: inspect(num_rows),


### PR DESCRIPTION
Datadog does not enable deployment tracking for tracers with a `type` of `:db` .  Changing it to custom allows it to pick up the version tag and use it for it's deployment tracking features. 