### PR TITLE
Allow passing custom tags through telemetry_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ config :my_app, MyApp.Repo,
   ]
 ```
 
-## Customizing Span Resources
+## Customizing Span Resources and Tags
 
 By default, SpandexEcto uses the query as name for the span's resource. In
 order get a better feeling for the context of your spans, you can label your
-span's resources using the option [`:telemetry_options`](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
+span's resources and tags using the option [`:telemetry_options`](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
 of almost all of `Ecto.Repo`'s repository functions.
 
 ### Examples
 
 ```elixir
 Repo.all(query, telemetry_options: [spandex_resource: "users-with-addresses"])
-Repo.get!(User, id, telemetry_options: [spandex_resource: "get-user"])
+Repo.get!(User, id, telemetry_options: [spandex_resource: "get-user", spandex_tags: [foo: "bar"]])
 ```

--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -119,16 +119,17 @@ defmodule SpandexEcto.EctoLogger do
   defp to_nanoseconds(time) when is_integer(time), do: System.convert_time_unit(time, :native, :nanosecond)
   defp to_nanoseconds(_time), do: 0
 
-  defp tags(%{params: params}) when is_list(params) do
+  defp tags(%{params: params, tags: tags}) when is_list(params) do
     param_count =
       params
       |> Enum.count()
       |> to_string()
 
-    [
+    Keyword.merge(tags,
       param_count: param_count
-    ]
+    )
   end
 
+  defp tags(%{tags: tags}) when is_list(tags), do: tags
   defp tags(_), do: []
 end

--- a/lib/spandex_ecto/telemetry_adapter.ex
+++ b/lib/spandex_ecto/telemetry_adapter.ex
@@ -20,7 +20,8 @@ defmodule SpandexEcto.TelemetryAdapter do
       decode_time: Map.get(measurements, :decode_time, 0),
       queue_time: Map.get(measurements, :queue_time, 0),
       result: wrap_result(metadata.result),
-      resource: get_in(metadata, [:options, :spandex_resource])
+      resource: get_in(metadata, [:options, :spandex_resource]),
+      tags: get_in(metadata, [:options, :spandex_tags]) || []
     }
 
     EctoLogger.trace(log_entry, "#{repo_name}_database", config)


### PR DESCRIPTION
Similar to #27, this allows consumers to pass custom span tags through `telemetry_options`.