### PR TITLE
Fix incorrectly categorized Ecto spans

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -60,7 +60,7 @@ defmodule SpandexEcto.EctoLogger do
 
       if queue_time != 0 do
         tracer.start_span("queue")
-        tracer.update_span(service: service, start: start, completion_time: start + queue_time)
+        tracer.update_span(type: :db, service: service, start: start, completion_time: start + queue_time)
         tracer.finish_span()
       end
 
@@ -68,6 +68,7 @@ defmodule SpandexEcto.EctoLogger do
         tracer.start_span("run_query")
 
         tracer.update_span(
+          type: :db,
           service: service,
           start: start + queue_time,
           completion_time: start + queue_time + query_time
@@ -80,6 +81,7 @@ defmodule SpandexEcto.EctoLogger do
         tracer.start_span("decode")
 
         tracer.update_span(
+          type: :db,
           service: service,
           start: start + queue_time + query_time,
           completion_time: now


### PR DESCRIPTION
I use Spandex to send traces to Datadog in two different Elixir projects, using `spandex_phoenix` and `spandex_ecto` in conjunction with `spandex_datadog`. I've noticed that there are some database spans that are incorrectly categorized as Web spans in the spans view, and I've traced the issue back to how `spandex_ecto` creates the spans. You can see the problem in these screenshots:

![screenshot-2022-05-30-10:25:17](https://user-images.githubusercontent.com/45771/170951118-e1c05ebf-6ac0-4dd0-9295-7cb8510c4f11.png)

![screenshot-2022-05-30-10:26:22](https://user-images.githubusercontent.com/45771/170951113-dfed92d4-b12c-42b3-ac6f-d302dccb79f1.png)


As you can see, the first screenshot is showing the Web spans for a trace in Datadog with some Ecto operations. Those are the `queue`, `run_query` and `decode` spans. Switching to the DB spans shows the same operation, but this time it's the `query` span. 

This PR aims to correct this small inconvenience.
