### PR TITLE
Config removing detailed spans

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -21,6 +21,7 @@ defmodule SpandexEcto.EctoLogger do
     tracer = config[:tracer] || raise "tracer is a required option for #{inspect(__MODULE__)}"
     service = config[:service] || :ecto
     truncate = config[:truncate] || 5000
+    emit_detailed_spans = Keyword.get(config, :emit_detailed_spans, true)
 
     if tracer.current_trace_id() do
       now = :os.system_time(:nano_seconds)
@@ -58,34 +59,36 @@ defmodule SpandexEcto.EctoLogger do
 
       report_error(tracer, log_entry)
 
-      if queue_time != 0 do
-        tracer.start_span("queue")
-        tracer.update_span(service: service, start: start, completion_time: start + queue_time)
-        tracer.finish_span()
-      end
+      if emit_detailed_spans do
+        if queue_time != 0 do
+          tracer.start_span("queue")
+          tracer.update_span(service: service, start: start, completion_time: start + queue_time)
+          tracer.finish_span()
+        end
 
-      if query_time != 0 do
-        tracer.start_span("run_query")
+        if query_time != 0 do
+          tracer.start_span("run_query")
 
-        tracer.update_span(
-          service: service,
-          start: start + queue_time,
-          completion_time: start + queue_time + query_time
-        )
+          tracer.update_span(
+            service: service,
+            start: start + queue_time,
+            completion_time: start + queue_time + query_time
+          )
 
-        tracer.finish_span()
-      end
+          tracer.finish_span()
+        end
 
-      if decoding_time != 0 do
-        tracer.start_span("decode")
+        if decoding_time != 0 do
+          tracer.start_span("decode")
 
-        tracer.update_span(
-          service: service,
-          start: start + queue_time + query_time,
-          completion_time: now
-        )
+          tracer.update_span(
+            service: service,
+            start: start + queue_time + query_time,
+            completion_time: now
+          )
 
-        tracer.finish_span()
+          tracer.finish_span()
+        end
       end
 
       tracer.finish_span()


### PR DESCRIPTION
This PR adds configuration flag `emit_detailed_spans` passed to `SpandexEcto.EctoLogger`. 
This flag can be set either in application config:
```elixir
config :spandex_ecto, SpandexEcto.EctoLogger, tracer: MyApp.Tracer, emit_detailed_spans: false
```

Or via the config argument in `:telemetry.attach/4` 
```elixir
:telemetry.attach(
  …
  &SpandexEcto.TelemetryAdapter.handle_event/4,
  emit_detailed_spans: false
)
```
This config is later passed to `SpandexEcto.TelemetryAdapter.handle_event/4` (it happens in [execute](https://github.com/beam-telemetry/telemetry/blob/v1.2.1/src/telemetry.erl#L160)).

Setting `emit_detailed_spans: false` will result in removing spans queue, run_query and decode, leaving only query span.
The change backward compatible. The default value (when the flag is not set) is `true`, meaning that the details spans are emitted like without this change. 
